### PR TITLE
Py3.9 Compatibility: Replace `getiterator` with `iter`

### DIFF
--- a/parser_methods.py
+++ b/parser_methods.py
@@ -457,8 +457,8 @@ def _docx_to_text(action_result, docx_file):
         fp.close()
         root = ElementTree.fromstring(txt)
         paragraphs = []
-        for paragraph in root.getiterator(PARA):
-            texts = [node.text for node in paragraph.getiterator(TEXT) if node.text]
+        for paragraph in root.iter(PARA):
+            texts = [node.text for node in paragraph.iter(TEXT) if node.text]
             if texts:
                 paragraphs.append(''.join(texts))
 

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fixed failing to parse files with "docx" extension in Python 3.9


### PR DESCRIPTION
### What's expected:
* xml.etree.ElementTree.Element.getiterator() has been deprecated since Python 2.7, and has been removed in Python 3.9. Replace all instances of Element.getiterator(tag) with Element.iter(tag) in ase/io/exciting.py. This MR also removes extraneous whitespace on otherwise empty lines in that file.
* Did global replacement here to ensure this won't show up again.
* This is required to fix Parser 001 playbook.

### What's happening:
* parser_001 pb is failing => Failed integration tests on py3.9

### Test 
* Py3.9 pipeline: pipelines/4558345
* Py3.6 pipeline is passing in this PR.

Source: https://docs.python.org/3.9/whatsnew/3.9.html#removed