### PR TITLE
chore(docs): Fix release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Parser
 
 Publisher: Splunk  
-Connector Version: 2.10.3  
+Connector Version: 2.10.5  
 Product Vendor: Splunk  
 Product Name: Parser  
 Product Version Supported (regex): ".\*"  

--- a/parser.json
+++ b/parser.json
@@ -9,7 +9,7 @@
     "product_name": "Parser",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "app_version": "2.10.4",
+    "app_version": "2.10.5",
     "fips_compliant": true,
     "license": "Copyright (c) 2017-2024 Splunk Inc.",
     "utctime_updated": "2024-12-23T21:01:21.000000Z",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-PAPP-35228 Fix: Extract Indicators of Compromise from docx files with embedded HTML
+* PAPP-35228 Fix: Extract Indicators of Compromise from docx files with embedded HTML


### PR DESCRIPTION
This should fix the `unreleased.md` failure introduced by https://github.com/splunk-soar-connectors/parser/pull/42