### PR TITLE
fix: harden Parser IOC and PDF processing

### DIFF
--- a/parser_email.py
+++ b/parser_email.py
@@ -1134,7 +1134,15 @@ def _del_tmp_dirs() -> None:
 def _int_process_email(rfc822_email: str, email_id: str, start_time_epoch: int) -> tuple[bool, str, list[dict[str, Any]]]:
     global _parser_state
 
-    mail = email.message_from_string(rfc822_email)
+    try:
+        mail = email.message_from_string(rfc822_email)
+    except Exception as e:
+        error_code, error_message = _get_error_message_from_exception(e)
+        error_text = f"Error Code: {error_code}. Error Message: {error_message}"
+        message = f"Error in email.message_from_string: {error_text}"
+        _error_print(message)
+        _dump_error_log(e)
+        return phantom.APP_ERROR, message, []
 
     ret_val = phantom.APP_SUCCESS
 

--- a/parser_email.py
+++ b/parser_email.py
@@ -132,8 +132,10 @@ PROC_EMAIL_JSON_EMAIL_HEADERS = "email_headers"
 PROC_EMAIL_CONTENT_TYPE_MESSAGE = "message/rfc822"
 
 URI_REGEX = r"h(?:tt|xx)p[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"
-EMAIL_REGEX = r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b"
-EMAIL_REGEX2 = r'".*"@[A-Z0-9.-]+\.[A-Z]{2,}\b'
+# Fixed bounds prevent attacker-controlled text from driving unbounded regex
+# backtracking. They cover SMTP's 64-octet local part and 255-octet domain.
+EMAIL_REGEX = r"\b[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,255}\.[A-Z]{2,63}\b"
+EMAIL_REGEX2 = r'"[^"\r\n]{0,64}"@[A-Z0-9.-]{1,255}\.[A-Z]{2,63}\b'
 HASH_REGEX = r"\b[0-9a-fA-F]{32}\b|\b[0-9a-fA-F]{40}\b|\b[0-9a-fA-F]{64}\b"
 IP_REGEX = r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"
 IPV6_REGEX = r"\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|"

--- a/parser_email.py
+++ b/parser_email.py
@@ -131,7 +131,12 @@ PROC_EMAIL_JSON_MSG_ID = "message_id"
 PROC_EMAIL_JSON_EMAIL_HEADERS = "email_headers"
 PROC_EMAIL_CONTENT_TYPE_MESSAGE = "message/rfc822"
 
-URI_REGEX = r"h(?:tt|xx)p[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"
+# WHATWG URL code points include non-ASCII scalar values. Keep the existing
+# ASCII/percent behavior and admit Unicode without also admitting C0 controls.
+URI_REGEX = (
+    r"h(?:tt|xx)p[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#]|[!*\(\),]|"
+    r"(?:%[0-9a-fA-F][0-9a-fA-F])|[\u00A0-\uD7FF\uE000-\U0010FFFD])+"
+)
 # Fixed bounds prevent attacker-controlled text from driving unbounded regex
 # backtracking. They cover SMTP's 64-octet local part and 255-octet domain.
 EMAIL_REGEX = r"\b[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,255}\.[A-Z]{2,63}\b"

--- a/parser_email.py
+++ b/parser_email.py
@@ -239,6 +239,12 @@ def _clean_url(url: str) -> str:
     return url
 
 
+def _normalize_browser_url(url: str) -> str:
+    """Apply the WHATWG parser's input whitespace normalization."""
+    url = re.sub(r"[\t\r\n]", "", url)
+    return re.sub(r"^[\x00-\x20]+|[\x00-\x20]+$", "", url)
+
+
 def is_ipv6(input_ip: str) -> bool:
     try:
         socket.inet_pton(socket.AF_INET6, input_ip)
@@ -323,18 +329,15 @@ def _extract_urls_domains(file_data: str, urls: set[str], domains: set[str]) -> 
             uri_text = [x for x in uri_text if x.startswith("http")]
             if uri_text:
                 uris.extend(uri_text)
-    else:
-        # To unescape html escaped body
-        file_data = unescape(file_data)
-
-        # Parse it as a text file
-        uris = re.findall(uri_regexc, file_data)
-        if uris:
-            uris = [_clean_url(x) for x in uris]
+    # Scan body text even when href/src attributes exist. Messages commonly
+    # contain browser-copyable links only in prose alongside unrelated tags.
+    text_uris = re.findall(uri_regexc, unescape(file_data))
+    uris.extend(_clean_url(uri) for uri in text_uris)
 
     validate_url = URLValidator(schemes=["http", "https"])
     validated_urls = list()
     for url in uris:
+        url = _normalize_browser_url(url)
         try:
             validate_url(url)
             validated_urls.append(url)

--- a/parser_methods.py
+++ b/parser_methods.py
@@ -341,58 +341,65 @@ class PDFXrefObjectsToXML:
         return buf.getvalue()
 
     @classmethod
-    def dump_xml(cls, text: str, obj: Any) -> str:
-        """Convert PDF xref object to XML"""
+    def _append_xml(cls, parts: list[str], obj: Any) -> None:
+        """Append one PDF xref object as XML fragments."""
         if obj is None:
-            text += "<null />"
-            return text
+            parts.append("<null />")
+            return
 
         if isinstance(obj, dict):
-            text += f'<dict size="{len(obj)}">\n'
+            parts.append(f'<dict size="{len(obj)}">\n')
             for key, value in obj.items():
-                text += f"<key>\n{key}\n</key>\n"
-                text += "<value>"
-                text = cls.dump_xml(text, value)
-                text += "</value>\n"
-            text += "</dict>"
-            return text
+                parts.append(f"<key>\n{key}\n</key>\n")
+                parts.append("<value>")
+                cls._append_xml(parts, value)
+                parts.append("</value>\n")
+            parts.append("</dict>")
+            return
 
         if isinstance(obj, list):
-            text += f'<list size="{len(obj)}">\n'
+            parts.append(f'<list size="{len(obj)}">\n')
             for value in obj:
-                text = cls.dump_xml(text, value)
-                text += "\n"
-            text += "</list>"
-            return text
+                cls._append_xml(parts, value)
+                parts.append("\n")
+            parts.append("</list>")
+            return
 
         if isinstance(obj, bytes):
-            text += f'<string size="{len(obj)}">\n{cls.encode(obj)}\n</string>'
-            return text
+            parts.append(f'<string size="{len(obj)}">\n{cls.encode(obj)}\n</string>')
+            return
 
         if isinstance(obj, PDFStream):
-            text += "<stream>\n<props>\n"
-            text = cls.dump_xml(text, obj.attrs)
-            text += "\n</props>\n"
-            text += "</stream>"
-            return text
+            parts.append("<stream>\n<props>\n")
+            cls._append_xml(parts, obj.attrs)
+            parts.append("\n</props>\n")
+            parts.append("</stream>")
+            return
 
         if isinstance(obj, PDFObjRef):
-            text += f'<ref id="{obj.objid}" />'
-            return text
+            parts.append(f'<ref id="{obj.objid}" />')
+            return
 
         if isinstance(obj, PSKeyword):
-            text += f"<keyword>\n{obj.name}\n</keyword>"
-            return text
+            parts.append(f"<keyword>\n{obj.name}\n</keyword>")
+            return
 
         if isinstance(obj, PSLiteral):
-            text += f"<literal>\n{obj.name}\n</literal>"
-            return text
+            parts.append(f"<literal>\n{obj.name}\n</literal>")
+            return
 
         if isnumber(obj):
-            text += f"<number>\n{obj}\n</number>"
-            return text
+            parts.append(f"<number>\n{obj}\n</number>")
+            return
 
         raise TypeError(f"Unable to extract the object from PDF. Reason: {obj}")
+
+    @classmethod
+    def dump_xml(cls, text: str, obj: Any) -> str:
+        """Convert PDF xref object to XML."""
+        parts = [text]
+        cls._append_xml(parts, obj)
+        return "".join(parts)
 
     @classmethod
     def dump_trailers(cls, text: str, doc: PDFDocument) -> str:
@@ -408,7 +415,7 @@ class PDFXrefObjectsToXML:
     def convert_objects_to_xml_text(cls, text: str, doc: PDFDocument) -> str:
         """Iterate trough xrefs and convert objects of xref to XML"""
         visited = set()
-        text += "<pdf>"
+        parts = [text, "<pdf>"]
         for xref in doc.xrefs:
             for obj_id in xref.get_objids():
                 if obj_id in visited:
@@ -418,14 +425,16 @@ class PDFXrefObjectsToXML:
                     obj = doc.getobj(obj_id)
                     if obj is None:
                         continue
-                    text += f'<object id="{obj_id}">\n'
-                    text = cls.dump_xml(text, obj)
-                    text += "\n</object>\n\n"
+                    parts.append(f'<object id="{obj_id}">\n')
+                    cls._append_xml(parts, obj)
+                    parts.append("\n</object>\n\n")
                 except PDFObjectNotFound as e:
                     raise PDFObjectNotFound(f"While converting PDF to xml objects PDF object not found. Reason: {e}")
-        cls.dump_trailers(text, doc)
-        text += "</pdf>"
-        return text
+        # dump_trailers historically discarded its serialized trailer value,
+        # and convert_objects_to_xml_text discarded its return value. Preserve
+        # the existing output while avoiding that wasted traversal.
+        parts.append("</pdf>")
+        return "".join(parts)
 
     @classmethod
     def pdf_xref_objects_to_xml(cls, pdf_file: str) -> str:

--- a/parser_methods.py
+++ b/parser_methods.py
@@ -49,7 +49,12 @@ if TYPE_CHECKING:
 _container_common = {"run_automation": False}  # Don't run any playbooks, when this artifact is added
 
 
-URI_REGEX = r"h(?:tt|xx)p[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"
+# WHATWG URL code points include non-ASCII scalar values. Keep the existing
+# ASCII/percent behavior and admit Unicode without also admitting C0 controls.
+URI_REGEX = (
+    r"h(?:tt|xx)p[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#]|[!*\(\),]|"
+    r"(?:%[0-9a-fA-F][0-9a-fA-F])|[\u00A0-\uD7FF\uE000-\U0010FFFD])+"
+)
 # Fixed bounds prevent attacker-controlled text from driving unbounded regex
 # backtracking. They cover SMTP's 64-octet local part and 255-octet domain.
 EMAIL_REGEX = r"\b[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,255}\.[A-Z]{2,63}\b"

--- a/parser_methods.py
+++ b/parser_methods.py
@@ -50,8 +50,10 @@ _container_common = {"run_automation": False}  # Don't run any playbooks, when t
 
 
 URI_REGEX = r"h(?:tt|xx)p[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"
-EMAIL_REGEX = r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b"
-EMAIL_REGEX2 = r'".*"@[A-Z0-9.-]+\.[A-Z]{2,}\b'
+# Fixed bounds prevent attacker-controlled text from driving unbounded regex
+# backtracking. They cover SMTP's 64-octet local part and 255-octet domain.
+EMAIL_REGEX = r"\b[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,255}\.[A-Z]{2,63}\b"
+EMAIL_REGEX2 = r'"[^"\r\n]{0,64}"@[A-Z0-9.-]{1,255}\.[A-Z]{2,63}\b'
 HASH_REGEX = r"\b[0-9a-fA-F]{32}\b|\b[0-9a-fA-F]{40}\b|\b[0-9a-fA-F]{64}\b"
 IP_REGEX = r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"
 IPV6_REGEX = (

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Handle recursive email parser failures without escaping the connector action.
 * Build PDF xref XML with fragment lists to avoid quadratic string copying.
 * Extract internationalized URLs so IDN homograph indicators are not missed.
+* Extract prose URLs alongside HTML links and normalize browser-clickable whitespace.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Chore: prepare the connector vulnerability remediation baseline.
+* Fix email IOC patterns to use bounded matching on untrusted input.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Chore: prepare the connector vulnerability remediation baseline.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Fix email IOC patterns to use bounded matching on untrusted input.
+* Handle recursive email parser failures without escaping the connector action.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Fix email IOC patterns to use bounded matching on untrusted input.
 * Handle recursive email parser failures without escaping the connector action.
+* Build PDF xref XML with fragment lists to avoid quadratic string copying.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Fix email IOC patterns to use bounded matching on untrusted input.
 * Handle recursive email parser failures without escaping the connector action.
 * Build PDF xref XML with fragment lists to avoid quadratic string copying.
+* Extract internationalized URLs so IDN homograph indicators are not missed.


### PR DESCRIPTION
This draft starts the Parser connector remediation under PAPP-37970 / ESPM-5228.\n\nDirect connector fixes:\n- PSAAS-30961 / VULN-93686 / FS-1790: bound email IOC regex work\n- PSAAS-31877 / VULN-94601 / FS-3123: extract validated internationalized URLs\n- PSAAS-31884 / VULN-94608 / FS-3130: handle recursive RFC822 parser failures\n- PSAAS-32269 / VULN-94992 / FS-3515: serialize xref XML in linear time\n- PSAAS-32443 / VULN-95166 / FS-3689: capture browser-clickable prose and whitespace-obfuscated URLs\n\nConnector-owned dependency work is in draft phantomcyber/pdfminer.six PR #2:\nhttps://github.com/phantomcyber/pdfminer.six/pull/2\n\nThe Parser dependency pin will be added after that PR has a durable merge SHA. This PR must remain draft until then.\n\nExcluded pending human/product guidance:\n- PSAAS-31902 proposes an arbitrary 500-textbox semantic cap\n- PSAAS-31980 proposes a cumulative 65,536 CMap mapping cap not clearly guaranteed by the PDF/CMap specifications\n\nValidation:\n- focused regex, IDN, WHATWG normalization, recursive-error syntax, and xref output-compatibility checks pass\n- Python compilation and diff checks pass\n- Semgrep passes under Python 3.13 in a clean pre-commit environment; the host-default Python 3.14/protobuf combination crashes before scanning\n- all commits are signed\n- generated dependency/copyright updates are intentionally held for the dependency-pin commit\n\nWritten by Codex on behalf of Jacob D.